### PR TITLE
Add Setting to disable Magical Hearse ingame

### DIFF
--- a/MagicalHearseSystem.cs
+++ b/MagicalHearseSystem.cs
@@ -33,6 +33,8 @@ public sealed partial class MagicalHearseSystem : GameSystemBase
 
     protected override void OnUpdate()
     {
+        if (!Setting.Instance.EnableMagicalHearse)
+            return;
         var deadCitizens = _deadCitizenQuery.ToEntityArray(Allocator.Temp);
 
         foreach (var entity in deadCitizens)

--- a/Mod.cs
+++ b/Mod.cs
@@ -25,10 +25,12 @@ public class Mod : IMod
             Log.Info($"Current mod asset at {asset.path}");
 
         m_Setting = new Setting(this);
-            m_Setting.RegisterInOptionsUI();
-            GameManager.instance.localizationManager.AddSource("en-US", new LocaleEN(m_Setting));
-            AssetDatabase.global.LoadSettings(nameof(MagicalHearse), m_Setting, new Setting(this));
-            Setting.Instance = m_Setting;updateSystem.UpdateAt<MagicalHearseSystem>(SystemUpdatePhase.GameSimulation);
+        m_Setting.RegisterInOptionsUI();
+        GameManager.instance.localizationManager.AddSource("en-US", new LocaleEN(m_Setting));
+        AssetDatabase.global.LoadSettings(nameof(MagicalHearse), m_Setting, new Setting(this));
+        Setting.Instance = m_Setting;
+
+        updateSystem.UpdateAt<MagicalHearseSystem>(SystemUpdatePhase.GameSimulation);
     }
 
     public void OnDispose()

--- a/Mod.cs
+++ b/Mod.cs
@@ -8,6 +8,7 @@ namespace MagicalHearse;
 
 public class Mod : IMod
 {
+    private Setting m_Setting;
     public static ILog Log = LogManager.GetLogger($"{nameof(MagicalHearse)}.{nameof(Mod)}").SetShowsErrorsInUI(
 #if !DEBUG
         false
@@ -23,7 +24,11 @@ public class Mod : IMod
         if (GameManager.instance.modManager.TryGetExecutableAsset(this, out var asset))
             Log.Info($"Current mod asset at {asset.path}");
 
-        updateSystem.UpdateAt<MagicalHearseSystem>(SystemUpdatePhase.GameSimulation);
+        m_Setting = new Setting(this);
+            m_Setting.RegisterInOptionsUI();
+            GameManager.instance.localizationManager.AddSource("en-US", new LocaleEN(m_Setting));
+            AssetDatabase.global.LoadSettings(nameof(MagicalHearse), m_Setting, new Setting(this));
+            Setting.Instance = m_Setting;updateSystem.UpdateAt<MagicalHearseSystem>(SystemUpdatePhase.GameSimulation);
     }
 
     public void OnDispose()

--- a/Setting.cs
+++ b/Setting.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Colossal;
+using Colossal.IO.AssetDatabase;
+using Game.Modding;
+using Game.Settings;
+using Game.UI;
+using Game.UI.Widgets;
+using System.Collections.Generic;
+using Colossal.Logging;
+using Game.UI.Menu;
+
+namespace MagicalHearse
+{
+    [FileLocation($"ModsSettings/{nameof(MagicalHearse)}/{nameof(MagicalHearse)}")]
+    public class Setting : ModSetting
+    {
+
+        public const string kMainSection = "Settings";
+        public static Setting Instance;
+
+        public Setting(IMod mod) : base(mod)
+        {
+
+        }
+
+        [SettingsUISection(kMainSection)] public bool EnableMagicalHearse { get; set; } = true;
+
+        public override void SetDefaults()
+        {
+            EnableMagicalHearse = true;
+        }
+    }
+
+    public class LocaleEN : IDictionarySource
+    {
+        private readonly Setting m_Setting;
+
+        public LocaleEN(Setting setting)
+        {
+            m_Setting = setting;
+        }
+
+        public IEnumerable<KeyValuePair<string, string>> ReadEntries(IList<IDictionaryEntryError> errors,
+            Dictionary<string, int> indexCounts)
+        {
+            return new Dictionary<string, string>
+            {
+                {m_Setting.GetSettingsLocaleID(), "Asset Packs Manager"},
+                { m_Setting.GetOptionTabLocaleID(Setting.kMainSection), "Settings" },
+
+                {m_Setting.GetOptionLabelLocaleID(nameof(Setting.EnableMagicalHearse)), "Enable Magical Hearse"},
+                {
+                    m_Setting.GetOptionDescLocaleID(nameof(Setting.EnableMagicalHearse)),
+                    $"Enables the magical hearse. Dead citizens will disappear automatically."
+                },
+            };
+        }
+
+
+        public void Unload()
+        {
+        }
+    }
+}

--- a/Setting.cs
+++ b/Setting.cs
@@ -14,8 +14,6 @@ namespace MagicalHearse
     [FileLocation($"ModsSettings/{nameof(MagicalHearse)}/{nameof(MagicalHearse)}")]
     public class Setting : ModSetting
     {
-
-        public const string kMainSection = "Settings";
         public static Setting Instance;
 
         public Setting(IMod mod) : base(mod)
@@ -23,7 +21,7 @@ namespace MagicalHearse
 
         }
 
-        [SettingsUISection(kMainSection)] public bool EnableMagicalHearse { get; set; } = true;
+        public bool EnableMagicalHearse { get; set; } = true;
 
         public override void SetDefaults()
         {
@@ -45,9 +43,7 @@ namespace MagicalHearse
         {
             return new Dictionary<string, string>
             {
-                {m_Setting.GetSettingsLocaleID(), "Asset Packs Manager"},
-                { m_Setting.GetOptionTabLocaleID(Setting.kMainSection), "Settings" },
-
+                {m_Setting.GetSettingsLocaleID(), "Magical Hearse"},
                 {m_Setting.GetOptionLabelLocaleID(nameof(Setting.EnableMagicalHearse)), "Enable Magical Hearse"},
                 {
                     m_Setting.GetOptionDescLocaleID(nameof(Setting.EnableMagicalHearse)),


### PR DESCRIPTION
I personally use this mod to get rid of death waves. I enable it for a few seconds and then play with normal gameplay again. I added ingame settings (Default: Enabled) so other players can do the same without having to disable the mod.

The default behavior does not change.

Please note that I was not able to integrate the changes with the BurstCompile PR, maybe one would need to enable/disable the whole magical system by the settings for that to work.