### PR TITLE
Version 1.2.0

### DIFF
--- a/MagicalHearse.csproj
+++ b/MagicalHearse.csproj
@@ -1,21 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
-		<TargetFramework>net472</TargetFramework>
-		<LangVersion>9</LangVersion>
 		<Configurations>Debug;Release</Configurations>
-		<Version>1.1.0</Version>
-		
-		<!--The folder where Game.dll is located. Set it only if the game is not installed in the default location, otherwise keep it empty-->
-		<CustomManagedPath></CustomManagedPath>
-		
-		<!--Path to the text file where PDX account data is stored which is required to publish the mod-->
-		<!--Keep it outside of project in order to not commit it or share accidentally-->
-		<!--The file should contain 2 lines:-->
-		<!--Your.PDX@Account.login-->
-		<!--Your-PDX-Account-Pa$$word-->
-		<PDXAccountDataPath>..\..\Common\pdx_account.txt</PDXAccountDataPath>
-		
+		<Version>1.2.0</Version>
+
 		<!--The file where mod information which is required for publishing mod on PDX mods are stored-->
 		<PublishConfigurationPath>Properties\PublishConfiguration.xml</PublishConfigurationPath>
 	</PropertyGroup>

--- a/Mod.cs
+++ b/Mod.cs
@@ -3,7 +3,6 @@ using Colossal.Logging;
 using Game;
 using Game.Modding;
 using Game.SceneFlow;
-using Unity.Entities;
 
 namespace MagicalHearse
 {
@@ -35,12 +34,14 @@ namespace MagicalHearse
 
             updateSystem.UpdateAt<MagicalHearseSystem>(SystemUpdatePhase.GameSimulation);
 
-            World.DefaultGameObjectInjectionWorld.GetOrCreateSystemManaged<MagicalHearseSystem>().Enabled = m_Setting.EnableMagicalHearse;
+            updateSystem.World.GetOrCreateSystemManaged<MagicalHearseSystem>().Enabled = m_Setting.EnableMagicalHearse;
         }
 
         public void OnDispose()
         {
             Log.Info(nameof(OnDispose));
+            m_Setting?.UnregisterInOptionsUI();
+            m_Setting = null;
         }
     }
 }

--- a/Properties/PublishConfiguration.xml
+++ b/Properties/PublishConfiguration.xml
@@ -25,18 +25,15 @@ This mod works with new and existing saves (may take a few seconds to kick in af
 	<!--Link to the forum post where the mod can be discussed-->
 	<ForumLink Value="https://forum.paradoxplaza.com/forum/threads/magical-hearse.1689354/" />
 	<!--Version of the mod-->
-	<ModVersion Value="1.1.0" />
+	<ModVersion Value="1.2.0" />
 	<!--Recommended version of the base game to use the mod-->
-	<GameVersion Value="1.1.*" />
+	<GameVersion Value="1.3.*" />
 	<!--Dependency for the mod, can be set multiple times-->
 	<Dependency Id="" />
 	<!--Change log for new version. Single line or multi line. Supports minimal markdown subset-->
 	<ChangeLog>
-* Added a toggle for the mod in the settings, so you can enable/disable the magical hearse without restarting your game.
-
-* Improved performance. (Mod now uses Burst and updates less frequently)
-
-Thanks to Konsi/Mimonsi for the settings implementation.
+* Compatibility fix for the game update 1.3.3f1
+* MagicalHearse Job is now running parallel
   </ChangeLog>
 	<!--External link. supported types are discord, github, youtube, twitch, x, paypal, patreon-->
 	<ExternalLink Type="github" Url="https://github.com/Wayzware/MagicalHearse" />


### PR DESCRIPTION
_Compatibility fix for vanilla 1.3.3f1_

I received a request to fix the mod to be compatible with latest game update (it was crashing the game), but I also noticed few bugs in the code, so I fixed everything and improved few other minor things:
- rewrite to use the query directly, 
- schedule job as parallel, 
- simplify health problem check, 
- add missing `ReadOnly` field attributes, 
- unregister from`OptionsUI` on mod dispose

The project file contained few things that are no longer needed, so I deleted them (forced by game toolchain `.props` project files)